### PR TITLE
Upload XLA compiler outputs to GCS

### DIFF
--- a/llama_ref/Dockerfile
+++ b/llama_ref/Dockerfile
@@ -10,8 +10,12 @@ RUN apt-get update && apt-get install -y curl gnupg
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 
-# Install the Google Cloud SDK
-RUN apt-get update && apt-get install -y google-cloud-sdk git
+# Add the Cloud Storage FUSE distribution URL as a package source
+RUN echo "deb https://packages.cloud.google.com/apt gcsfuse-bullseye main" | tee /etc/apt/sources.list.d/gcsfuse.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
+# Install the Google Cloud SDK and GCS fuse
+RUN apt-get update && apt-get install -y google-cloud-sdk git fuse gcsfuse && gcsfuse -v
 
 # Set the default Python version to 3.10
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.10 1

--- a/llama_ref/run_xpk.py
+++ b/llama_ref/run_xpk.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+import os
+import sys
+import subprocess
+
+# Some passes in XLA can only dump to regular folders. Hence,
+# mount the GCS bucket at gs://hanq-llama at `/tmp/gcs-mount` using gcsfuse.
+gcs_mount = '/tmp/gcs-mount'
+os.makedirs(gcs_mount, exist_ok=True)
+subprocess.run(['gcsfuse', 'hanq-llama', gcs_mount], check=True)
+
+# These are set by GKE automatically.
+worker_id = os.getenv("TPU_WORKER_ID", "0")
+slice_id = os.getenv("MEGASCALE_SLICE_ID", "0")
+
+# Configure XLA graph dump path before doing anything else.
+date_string = datetime.now().strftime("%Y%m%d-%H%M")
+jobset_name = os.getenv("JOBSET_NAME", date_string)
+xla_dump_path = f'{gcs_mount}/llama3-{slice_id}-{worker_id}/xla_dumps/{jobset_name}/'
+os.environ['XLA_FLAGS'] = os.getenv('XLA_FLAGS', '') + f' --xla_dump_to={xla_dump_path}'
+print(f"Dumping XLA compiler outputs to {xla_dump_path}")
+
+# Determine the profile dir
+profile_dir = f'{gcs_mount}/llama3-{slice_id}-{worker_id}/'
+
+# Exec into the training script.
+args = [sys.executable, "run.py"] + sys.argv[1:] + ['--profile_dir', profile_dir]
+env = os.environ.copy()
+os.execve(sys.executable, args, env)

--- a/llama_ref/run_xpk.sh
+++ b/llama_ref/run_xpk.sh
@@ -1,23 +1,27 @@
 #!/usr/bin/env bash
 
+set -eo
+
 ##### Runs SPMD training as an xpk job on a GKE cluster #####
 #
-# Example: ./run_xpk.sh --lr=0.001 --model_type=70B --batch_size=128 --use_custom_mesh
-#
-# To run this, a _source_ install of xpk is required to accesss the latest TPU.
+# To run this, a _source_ install of xpk is required to access the latest TPU.
 #
 # Example: pip install git+https://github.com/AI-Hypercomputer/xpk.git@main
 #
 
-CLUSTER_NAME=bodaborg-v6e-256
-DOCKER_URL=gcr.io/tpu-pytorch/llama3:latest
-NUM_SLICES=1
-TPU_TYPE=v6e-256
-ZONE=us-east5-c
-PROJECT_ID=tpu-prod-env-automated
+# Always build a new image. This is fast when cached.
+./buildpush.sh
+
+# You can override these by setting corresponding environment variables.
+: "${CLUSTER_NAME:=bodaborg-v6e-256}"
+: "${DOCKER_URL:=gcr.io/tpu-pytorch/llama3:latest}"
+: "${NUM_SLICES:=1}"
+: "${TPU_TYPE:=v6e-256}"
+: "${ZONE:=us-east5-c}"
+: "${PROJECT_ID:=tpu-prod-env-automated}"
 
 DATETIMESTR=$(date +%Y%m%d-%H%M%S)
-COMMAND="python run.py --batch_size=64 --model_type=70B --seqlen=8192 --use_custom_offload=False --model_impl=scan_manual --tp=4"
+COMMAND="python run_xpk.py --batch_size=64 --model_type=70B --seqlen=8192 --use_custom_offload=False --model_impl=scan_manual --tp=4"
 
 xpk workload create \
     --cluster ${CLUSTER_NAME} \


### PR DESCRIPTION
The only reliable way I found is to set the XLA_FLAGS env var before running any training script. So `run_xpk.py` is introduced for this purpose.

I also moved profile path logic there, and added a `./buildpush.sh` in `run_xpk.sh` so we don't forget to build the docker.

Tested: run `run_xpk.sh`