### PR TITLE
Fix/jax hg 03.py

### DIFF
--- a/jax-huggingface/jax_hg_03.py
+++ b/jax-huggingface/jax_hg_03.py
@@ -80,7 +80,7 @@ register_pytree_node(
 
 model = AutoModelForCausalLM.from_pretrained(
         "meta-llama/Llama-2-7b-hf", 
-        torch_dtype="bfloat16", device_map="cpu")
+        dtype="bfloat16", device_map="cpu")
         
 def shard_weights_llama(mesh, weights):
   result = {}


### PR DESCRIPTION
# Fixes & Observations

## 1. Loop Range Bug
The loop was off by one — it should include the endpoint properly:
```python
    for i in range(1, max_tokens):
```

## 2. Cache Length Formula
The correct formula should be:
```python
    max_cache_len = seq_length + max_tokens
```

## 3. Static Cache API Changes
I ran into issues with StaticCache because the API has changed.  
Here’s the workaround I’m using:
```python
    def _flatten_static_cache(cache):
        layers_keys = [layer.keys for layer in cache.layers]
        layers_values = [layer.values for layer in cache.layers]

        return (
            layers_keys,
            layers_values,
        ), (cache._config, cache.max_batch_size, cache.max_cache_len)


    def _unflatten_static_cache(aux, children):
        _config, max_batch_size, max_cache_len = aux
        cache = cache_utils.StaticCache(
            config=_config,
            max_batch_size=max_batch_size,
            max_cache_len=max_cache_len,
        )
        cache._config = _config
        layers_keys, layers_values = children

        for i, layer in enumerate(cache.layers):
            layer.keys = layers_keys[i]
            layer.values = layers_values[i]
            layer.max_batch_size, layer.num_heads, _, layer.head_dim = layers_keys[i].shape

        return cache
```
⚠️ This feels like a hack, since StaticCache uses lazy_init internally, which I can’t rely on (because it reinitializes a torch.Tensor).

## 4. FSDP vs DDP
I noticed that FSDP is significantly slower than DDP for a smaller model such as LLaMA-2 7B.  

---

# Open Question
Why isn’t the prefill step jitted?  